### PR TITLE
[Fix] cpu: x64: matmul: correct LDD when M == 1

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1500,7 +1500,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             "The first coordinate of every N_blk that is larger than LDB "
             "needs to be divisible by LDB");
 
-    bgmmc.LDD = dst_d.ndims() == 2 && dst_d.count_non_unit_dims(1)
+    bgmmc.LDD = dst_d.ndims() == 2 && bgmmc.M == 1
             ? bgmmc.N
             : dst_d.blocking_desc().strides[bgmmc.ndims - 2];
     bgmmc.LDC = bgmmc.use_buffer_c && bgmmc.nthr_k <= 1


### PR DESCRIPTION
# Description 
fix some test cases in 
smoke_dynamic/AUGRUCellCPUTest
smoke_static/AUGRUCellCPUTest

fork from https://github.com/uxlfoundation/oneDNN/pull/3355
Fixes MFDNN-13737

