### PR TITLE
[CPU] fix  matmul compress and LPT convoluton test case on avx2

### DIFF
--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -329,6 +329,7 @@ enum {
     key_decompression_zero_points,
     key_src_quantized,
     key_src_dequantized_scales,
+    key_src_grouped_sum,
     // These two keys should always be the last ones,
     // even though they are not in alphabetical order
     key_nested,

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -152,18 +152,7 @@ struct primitive_desc_t : public c_compatible {
     enum class arg_usage_t { unused, input, output };
     virtual arg_usage_t arg_usage(int arg) const {
         using types::is_zero_md;
-        if (arg & DNNL_ARG_ATTR_ZERO_POINTS) {
-            int zp_arg = arg & ~DNNL_ARG_ATTR_ZERO_POINTS;
-            return !attr()->zero_points_.has_default_values(zp_arg)
-                    ? arg_usage_t::input
-                    : arg_usage_t::unused;
-        }
-        if (arg & DNNL_ARG_ATTR_SCALES) {
-            int scale_arg = arg & ~DNNL_ARG_ATTR_SCALES;
-            return !attr()->scales_.has_default_values(scale_arg)
-                    ? arg_usage_t::input
-                    : arg_usage_t::unused;
-        }
+
         if ((arg & (DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC))
             && !attr()->input_zero_points_.has_default_values())
             return arg_usage_t::input;
@@ -174,7 +163,20 @@ struct primitive_desc_t : public c_compatible {
                 && !attr()->output_compensations_.has_default_values()
                 && arg != DNNL_ARG_SCRATCHPAD)
             return arg_usage_t::input;
-        
+
+        if (arg & DNNL_ARG_ATTR_ZERO_POINTS) {
+            int zp_arg = arg & ~DNNL_ARG_ATTR_ZERO_POINTS;
+            return !attr()->zero_points_.has_default_values(zp_arg)
+                ? arg_usage_t::input
+                : arg_usage_t::unused;
+        }
+        if (arg & DNNL_ARG_ATTR_SCALES) {
+            int scale_arg = arg & ~DNNL_ARG_ATTR_SCALES;
+            return !attr()->scales_.has_default_values(scale_arg)
+                ? arg_usage_t::input
+                : arg_usage_t::unused;
+        }
+
         if (arg == DNNL_ARG_SCRATCHPAD)
             return !is_zero_md(scratchpad_md()) ? arg_usage_t::output
                                                 : arg_usage_t::unused;

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -82,7 +82,8 @@ void brgemm_desc_t::cleanup_dst_md() {
 void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
         const brgemm_batch_element_t *batch, void *ptr_C, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values,
-        const void *ptr_wei_scales, const void *ptr_wei_zero_points, const void *ptr_src_scales, size_t ic) {
+        const void *ptr_wei_scales, const void *ptr_wei_zero_points,
+        const void *ptr_src_scales, const void *ptr_src_grouped_sum, size_t ic) {
     brgemm_kernel_params_t brgemm_p;
 
     brgemm_p.batch = batch;
@@ -105,6 +106,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
     brgemm_p.ptr_wei_scales = ptr_wei_scales;
     brgemm_p.ptr_wei_zero_points = ptr_wei_zero_points;
     brgemm_p.ptr_src_scales = ptr_src_scales;
+    brgemm_p.ptr_src_grouped_sum = ptr_src_grouped_sum;
     brgemm_p.ic = ic;
 
     assert(brg_kernel);
@@ -116,7 +118,8 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
         const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values,
-        const void *ptr_wei_scales, const void *ptr_wei_zero_points, const void *ptr_src_scales, size_t ic) {
+        const void *ptr_wei_scales, const void *ptr_wei_zero_points,
+        const void *ptr_src_scales, const void *ptr_src_grouped_sum, size_t ic) {
     brgemm_kernel_params_t brgemm_p;
 
     brgemm_p.batch = batch;
@@ -133,6 +136,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
     brgemm_p.ptr_wei_scales = ptr_wei_scales;
     brgemm_p.ptr_wei_zero_points = ptr_wei_zero_points;
     brgemm_p.ptr_src_scales = ptr_src_scales;
+    brgemm_p.ptr_src_grouped_sum = ptr_src_grouped_sum;
     brgemm_p.ic = ic;
     if (dynamic_values) {
         brgemm_p.dynamic_LDA = dynamic_values->dynamic_LDA;
@@ -148,7 +152,8 @@ void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
         const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values,
-        const void *ptr_wei_scales, const void *ptr_wei_zero_points, const void *ptr_src_scales, size_t ic) {
+        const void *ptr_wei_scales, const void *ptr_wei_zero_points,
+        const void *ptr_src_scales, const void *ptr_src_grouped_sum, size_t ic) {
     brgemm_kernel_params_t brgemm_p;
 
     brgemm_p.batch = batch;
@@ -178,6 +183,7 @@ void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
     brgemm_p.ptr_wei_scales = ptr_wei_scales;
     brgemm_p.ptr_wei_zero_points = ptr_wei_zero_points;
     brgemm_p.ptr_src_scales = ptr_src_scales;
+    brgemm_p.ptr_src_grouped_sum = ptr_src_grouped_sum;
     brgemm_p.ic = ic;
     if (dynamic_values) {
         brgemm_p.dynamic_LDA = dynamic_values->dynamic_LDA;
@@ -194,7 +200,8 @@ void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
         const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values,
-        const void *ptr_wei_scales, const void *ptr_wei_zero_points, const void *ptr_src_scales, size_t ic) {
+        const void *ptr_wei_scales, const void *ptr_wei_zero_points,
+        const void *ptr_src_scales, const void *ptr_src_grouped_sum, size_t ic) {
     brgemm_kernel_params_t brgemm_p;
 
     brgemm_p.batch = batch;
@@ -225,6 +232,7 @@ void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
     brgemm_p.ptr_wei_scales = ptr_wei_scales;
     brgemm_p.ptr_wei_zero_points = ptr_wei_zero_points;
     brgemm_p.ptr_src_scales = ptr_src_scales;
+    brgemm_p.ptr_src_grouped_sum = ptr_src_grouped_sum;
     brgemm_p.ic = ic;
     if (dynamic_values) {
         brgemm_p.dynamic_LDA = dynamic_values->dynamic_LDA;
@@ -340,6 +348,11 @@ status_t brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
         brg->src_sum_group_size = brg->rd_block;
         brg->src_grouped_sum_stride = div_up(wei_d.dims()[1], brg->src_sum_group_size);
     }
+
+    // avx2_vnni_2 kernel with xf16 data type requires blocked weights.
+    if (brg->isa_impl == avx2_vnni_2 && brg->is_xf16()
+            && brg->LDB % brg->ld_block > 0)
+        return status::unimplemented;
 
     return status::success;
 }

--- a/src/cpu/x64/brgemm/brgemm.hpp
+++ b/src/cpu/x64/brgemm/brgemm.hpp
@@ -184,7 +184,7 @@ void DNNL_API brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
         void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr,
         const void *ptr_wei_scales = nullptr, const void *ptr_wei_zero_points = nullptr,
-        const void *ptr_src_scales = nullptr, size_t ic = 0);
+        const void *ptr_src_scales = nullptr, const void *ptr_src_grouped_sum = nullptr, size_t ic = 0);
 
 /// Execute BRGEMM kernel (brgemm_offs and brgemm_strd version)
 ///
@@ -214,7 +214,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
         void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr,
         const void *ptr_wei_scales = nullptr, const void *ptr_wei_zero_points = nullptr,
-        const void *ptr_src_scales = nullptr, size_t ic = 0);
+        const void *ptr_src_scales = nullptr, const void *ptr_src_grouped_sum = nullptr, size_t ic = 0);
 
 /// Execute BRGEMM kernel (brgemm_addr version)
 ///
@@ -243,7 +243,7 @@ void DNNL_API brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr,
         const void *ptr_wei_scales = nullptr, const void *ptr_wei_zero_points = nullptr,
-        const void *ptr_src_scales = nullptr, size_t ic = 0);
+        const void *ptr_src_scales = nullptr, const void *ptr_src_grouped_sum = nullptr, size_t ic = 0);
 
 /// Execute BRGEMM kernel (brgemm_offs and brgemm_strd version)
 ///
@@ -276,7 +276,7 @@ void DNNL_API brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr,
         const void *ptr_wei_scales = nullptr, const void *ptr_wei_zero_points = nullptr,
-        const void *ptr_src_scales = nullptr, size_t ic = 0);
+        const void *ptr_src_scales = nullptr, const void *ptr_src_grouped_sum = nullptr, size_t ic = 0);
 
 /// AMX utilities: Creates a palette based on BRGEMM descriptor
 ///

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -580,6 +580,7 @@ struct brgemm_kernel_params_t {
     const void *ptr_wei_scales = nullptr;
     const void *ptr_wei_zero_points = nullptr;
     const void *ptr_src_scales = nullptr;
+    const void *ptr_src_grouped_sum = nullptr;
     size_t ic;
     dim_t dynamic_LDA = 0;
     dim_t dynamic_LDB = 0;

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -226,7 +226,8 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
         max_reg_count
                 = nstl::min(max_reg_count, max_isa_regs - max_bcst_regs - 5);
 
-    const int postops_regs = brg->attr()
+    // For dynamic quantization case it is more performant to maximize the amount of accumulators
+    const int postops_regs = brg->attr() && !brg->with_src_dyn_quant
             ? injector::aux_vec_count(
                     brg->attr()->post_ops_, brg->isa_impl, true)
             : 0;

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -663,29 +663,45 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
     const int max_vpad = nstl::max(
             brg->brgattr.max_top_vpad, brg->brgattr.max_bottom_vpad);
 
-    // iterate ld_block2 starting from 4 to allow bd_block larger than
-    // virtual padding
     int max_bcast_block {0}, min_bcast_block {0}, adj_ld_block2 {0};
-    bool few_regs = utils::one_of(brg->isa_impl, avx2, avx2_vnni, avx2_vnni_2);
-    few_regs |= brg->with_src_dyn_quant;
-    bool hint_n_bcast_1_load
-            = brg->brgattr.hint_loop_order == brgemm_lo_bl_1load;
-    for (int try_ld_block2 = 4; try_ld_block2 > 0; --try_ld_block2) {
-        adj_ld_block2 = calculate_ldb_params(brg, try_ld_block2);
-        brg->n_bcast_1_load
-                = (few_regs && adj_ld_block2 == 4) || hint_n_bcast_1_load;
+    if (brg->with_src_dyn_quant) {
+        adj_ld_block2 = calculate_ldb_params(brg, 4);
         max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
-        const auto bdb_tail = brg->bcast_dim % max_bcast_block;
-        min_bcast_block = bdb_tail > 0 ? bdb_tail : max_bcast_block;
-        if (min_bcast_block >= max_vpad) break;
+        // reduce 'ld_block2' to allow a larger 'bd_block'
+        if (is_superset(brg->isa_impl, avx2) && max_bcast_block < max_vpad) {
+            for (int try_ld_block2 = 2; try_ld_block2 > 0; --try_ld_block2) {
+                adj_ld_block2 = calculate_ldb_params(brg, try_ld_block2);
+                max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
+                if (max_bcast_block >= max_vpad) break;
+            }
+            // bcast block in brgemm kernel should be greater than virtual
+            // padding to avoid possible functional issues
+            if (max_bcast_block < max_vpad) return status::unimplemented;
+        }
+    } else {
+        // iterate ld_block2 starting from 4 to allow bd_block larger than
+        // virtual padding
+        bool few_regs = utils::one_of(brg->isa_impl, avx2, avx2_vnni, avx2_vnni_2);
+        bool hint_n_bcast_1_load
+            = brg->brgattr.hint_loop_order == brgemm_lo_bl_1load;
+        for (int try_ld_block2 = 4; try_ld_block2 > 0; --try_ld_block2) {
+            adj_ld_block2 = calculate_ldb_params(brg, try_ld_block2);
+            brg->n_bcast_1_load
+                = (few_regs && adj_ld_block2 == 4) || hint_n_bcast_1_load;
+            max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
+            const auto bdb_tail = brg->bcast_dim % max_bcast_block;
+            min_bcast_block = bdb_tail > 0 ? bdb_tail : max_bcast_block;
+            if (min_bcast_block >= max_vpad) break;
+        }
+        // bcast block in brgemm kernel should be greater than virtual
+        // padding to avoid possible functional issues
+        if (min_bcast_block < max_vpad) return status::unimplemented;
     }
-    // bcast block in brgemm kernel should be greater than virtual
-    // padding to avoid possible functional issues
-    if (min_bcast_block < max_vpad) return status::unimplemented;
 
     const int min_block = nstl::max(1, max_vpad);
 
     float best_bd_block_eff = 0.f;
+    if (max_bcast_block == 0) max_bcast_block = 1;
     brg->bd_block = max_bcast_block;
     for (int bd_block = max_bcast_block; bd_block >= min_block; bd_block--) {
         const auto bd_block_disb = static_cast<float>(brg->bcast_dim)

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -248,14 +248,10 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
     if (one_of(brg->dt_b, data_type::nf4) && brg->isa_impl == avx2) max_bcast_block -= 5;
     if (one_of(brg->dt_b, data_type::f4_e2m1) && brg->isa_impl == avx2) max_bcast_block -= 2;
     if (one_of(brg->dt_b, data_type::nf4, data_type::f4_e2m1) && brg->isa_impl != avx2) max_bcast_block -= 1;
-    if (brg->with_wei_decomp_zero_points && brg->wei_decomp_zero_points_stride == 0) max_bcast_block -= 1;
-    if (brg->with_src_dyn_quant) max_bcast_block -= 2;
-    if (brg->with_src_dyn_quant && brg->with_wei_decomp_zero_points && brg->wei_decomp_zero_points_stride != 0) max_bcast_block -= adj_ld_block2;
+    if (brg->with_wei_decomp_zero_points && brg->wei_decomp_zero_points_stride == 0 && !brg->with_src_dyn_quant) max_bcast_block -= 1;
+    if (brg->with_src_dyn_quant) max_bcast_block -= 1;
 
     max_bcast_block /= adj_ld_block2;
-    if (brg->with_src_dyn_quant) {
-        max_bcast_block /= 2;
-    }
 
     return max_bcast_block;
 }
@@ -718,14 +714,20 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
             ? 1
             : data_type_vnni_granularity(brg->dt_a);
     int rd_unroll = one_of(brg->dt_b, data_type::nf4, data_type::u4, data_type::s4, data_type::f4_e2m1) ? 32 : 4;
-    if (brg->with_grouped_wei_decomp) {
+    if (brg->with_grouped_wei_decomp && !brg->with_src_dyn_quant) {
         auto min_group_size = nstl::min(brg->wei_decomp_scales_group_size, brg->wei_decomp_zero_points_group_size);
         min_group_size = nstl::min(min_group_size, brg->src_scales_group_size);
         rd_unroll = nstl::min(rd_unroll, min_group_size / vnni_granularity);
         rd_unroll = nstl::min(rd_unroll, min_group_size / vnni_granularity);
+        brg->rd_block = rd_unroll * vnni_granularity;
+    } else if (brg->with_src_dyn_quant) {
+        brg->rd_block = brg->src_scales_group_size;
+        auto min_group_size = nstl::min(brg->wei_decomp_scales_group_size, brg->wei_decomp_zero_points_group_size);
+        brg->rd_block = nstl::min(brg->rd_block, min_group_size);
+    } else {
+        brg->rd_block = rd_unroll * vnni_granularity;
     }
 
-    brg->rd_block = rd_unroll * vnni_granularity;
     brg->rdb = brg->reduce_dim / brg->rd_block;
     brg->rdb_tail = brg->reduce_dim % brg->rd_block;
 

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -206,6 +206,7 @@ private:
     const reg64_t reg_aux_wei_zp = reg_rdb_loop;
     const reg64_t reg_ic = reg_rdb_loop;
     const reg64_t reg_src_scales = reg_rdb_loop;
+    const reg64_t reg_src_grouped_sum = reg_rdb_loop;
     const reg64_t reg_tmp_read_values = reg_rdb_loop;
 
     const reg64_t reg_aux_scales = reg_aux_B;
@@ -283,12 +284,13 @@ private:
     constexpr static int reg_src_scales_offs_ = 336;
     constexpr static int reg_aux_src_scales_offs_ = 344;
     constexpr static int reg_aux2_src_scales_offs_ = 352;
-    // constexpr static int stack_space_needed_ = 360;
+    constexpr static int reg_src_grouped_sum_offs_ = 360;
+    constexpr static int reg_aux_src_grouped_sum_offs_ = 368;
+    constexpr static int reg_aux2_src_grouped_sum_offs_ = 376;
     // these are used for FP8 as temporary push/pop spaces
-    constexpr static int reg_val_tmp_1_ = 368;
-    constexpr static int reg_val_tmp_2_ = 376;
-    constexpr static int stack_space_needed_ = 384;
-    // regsiters for dynamic quant
+    constexpr static int reg_val_tmp_1_ = 384;
+    constexpr static int reg_val_tmp_2_ = 392;
+    constexpr static int stack_space_needed_ = 400;
 
 
     bool is_ldb_loop_ = false;
@@ -322,16 +324,12 @@ private:
             used_vregs += 1;
         }
 
-        if (brg.with_wei_decomp_zero_points && brg.wei_decomp_zero_points_stride == 0) {
+        if (brg.with_wei_decomp_zero_points && brg.wei_decomp_zero_points_stride == 0 && !brg.with_src_dyn_quant) {
             used_vregs += 1;
         }
 
         if (brg.with_src_dyn_quant) {
-            used_vregs += 2;
-        }
-
-        if (brg.with_src_dyn_quant && brg.with_wei_decomp_zero_points && brg.wei_decomp_zero_points_stride != 0) {
-            used_vregs += brg.ld_block2;
+            used_vregs += 1;
         }
         return isa_num_vregs(brg.isa_impl) - used_vregs;
     }
@@ -983,14 +981,16 @@ void jit_brgemm_kernel_t<Wmm>::copy_post_ops_stack_values_to_aux(
         }
 
     }
-    if (brg.with_grouped_wei_decomp) {
-        mov(reg_ic, ptr[rsp + reg_ic_offs_]);
-        mov(ptr[rsp + reg_aux_ic_offs_], reg_ic);
-    }
     if (brg.with_src_dyn_quant) {
         mov(reg_src_scales, ptr[rsp + reg_src_scales_offs_]);
         mov(ptr[rsp + reg_aux_src_scales_offs_], reg_src_scales);
         mov(ptr[rsp + reg_aux2_src_scales_offs_], reg_src_scales);
+
+        if (brg.with_wei_decomp_zero_points) {
+            mov(reg_src_grouped_sum, ptr[rsp + reg_src_grouped_sum_offs_]);
+            mov(ptr[rsp + reg_aux_src_grouped_sum_offs_], reg_src_grouped_sum);
+            mov(ptr[rsp + reg_aux2_src_grouped_sum_offs_], reg_src_grouped_sum);
+        }
     }
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
         mov(reg_zp_comp_b, ptr[rsp + reg_zp_comp_b_offs_]);
@@ -1068,6 +1068,9 @@ void jit_brgemm_kernel_t<Wmm>::read_params() {
     if (brg.with_src_dyn_quant) {
         mov(reg_src_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
         mov(ptr[rsp + reg_src_scales_offs_], reg_src_scales);
+
+        mov(reg_src_grouped_sum, ptr[param1 + GET_OFF(ptr_src_grouped_sum)]);
+        mov(ptr[rsp + reg_src_grouped_sum_offs_], reg_src_grouped_sum);
     }
 
     if (brg.zp_type_c != brgemm_broadcast_t::none) {
@@ -1253,7 +1256,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
                     uni_vaddps(vmm_masked, vmm, ptr_C);
             } else {
                 vmaskmovps(vmm_prev_dst, vmm_tail_mask(), ptr_C);
-                if (brg.is_int8)
+                if (brg.is_int8 && !brg.with_src_dyn_quant)
                     uni_vpaddd(vmm, vmm, vmm_prev_dst);
                 else
                     uni_vaddps(vmm, vmm, vmm_prev_dst);
@@ -2373,27 +2376,6 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_dyn_quant(dim_t bd_block2,
         if (brg.req_s8s8_compensation) uni_vpaddb(v1, v1, vmm_inp_shift());
     };
 
-    auto vmm_accm_tmp = [&](int ld_block, int bd, int ld) {
-        int idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block) - ld_block - (bd * ld_block + ld);
-        return Vmm(idx);
-    };
-
-    auto vmm_zero_point = [&](int ld) {
-        int idx = isa_num_vregs(brg.isa_impl) - 3 - ld;
-        return Vmm(idx);
-    };
-
-    static const int8_t negative_one[64] = {
-        -1, -1, -1, -1, -1, -1, -1, -1,
-        -1, -1, -1, -1, -1, -1, -1, -1,
-        -1, -1, -1, -1, -1, -1, -1, -1,
-        -1, -1, -1, -1, -1, -1, -1, -1,
-        -1, -1, -1, -1, -1, -1, -1, -1,
-        -1, -1, -1, -1, -1, -1, -1, -1,
-        -1, -1, -1, -1, -1, -1, -1, -1,
-        -1, -1, -1, -1, -1, -1, -1, -1
-    };
-
     static const int8_t mask_low_half[64] = {
         0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
         0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
@@ -2404,48 +2386,19 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_dyn_quant(dim_t bd_block2,
     mov(ptr[rsp + reg_bdb_loop_offs_], reg_bdb_loop);
     mov(ptr[rsp + reg_ldb_loop_offs_], reg_ldb_loop);
 
-    auto reg_local_wei_scales = reg_bdb_loop;
-    auto reg_local_wei_zp = reg_ldb_loop;
-    auto reg_ptr = reg_local_wei_scales;
-
-    if (brg.with_wei_decomp_zero_points) {
-        mov(reg_local_wei_zp, ptr[rsp + reg_aux2_wei_zero_points_offs_]);
-        if (brg.wei_decomp_zero_points_stride == 0) {
-            auto reg_ptr_8 = Reg8(reg_ptr.getIdx());
-            mov(reg_ptr_8, ptr[reg_local_wei_zp]);
-            uni_vpbroadcastb(vmm_zero_point(0), reg_ptr_8);
-        } else {
-            static const int8_t index_table[64] = {
-                0x00, 0x00, 0x00, 0x00, 0x04, 0x04, 0x04, 0x04, 0x08, 0x08, 0x08, 0x08, 0x0C, 0x0C, 0x0C, 0x0C,
-                0x00, 0x00, 0x00, 0x00, 0x04, 0x04, 0x04, 0x04, 0x08, 0x08, 0x08, 0x08, 0x0C, 0x0C, 0x0C, 0x0C,
-                0x00, 0x00, 0x00, 0x00, 0x04, 0x04, 0x04, 0x04, 0x08, 0x08, 0x08, 0x08, 0x0C, 0x0C, 0x0C, 0x0C,
-                0x00, 0x00, 0x00, 0x00, 0x04, 0x04, 0x04, 0x04, 0x08, 0x08, 0x08, 0x08, 0x0C, 0x0C, 0x0C, 0x0C
-            };
-
-            auto vmm_indexes = Vmm(isa_num_vregs(brg.isa_impl) - 1);
-            mov(reg_ptr, (size_t)index_table);
-            uni_vmovups(vmm_indexes, ptr[reg_ptr]);
-
-            for (int ld = 0; ld < ld_block2; ld++) {
-                uni_vpmovzxbd(vmm_zero_point(ld), ptr[reg_local_wei_zp + ld * brg.ld_block * types::data_type_size(brg.wei_decomp_zero_points_dt)]);
-                vpshufb(vmm_zero_point(ld), vmm_zero_point(ld), vmm_indexes);
-            }
-        }
-    }
-
-    auto vmm_neg_one = Vmm(isa_num_vregs(brg.isa_impl) - 1);
-    mov(reg_ptr, (size_t)negative_one);
-    uni_vmovups(vmm_neg_one, ptr[reg_ptr]);
-
-    auto vmm_mask_low_half = Vmm(isa_num_vregs(brg.isa_impl) - 2);
+    auto reg_ptr = reg_bdb_loop;
+    auto vmm_mask_low_half = Vmm(isa_num_vregs(brg.isa_impl) - 1);
     mov(reg_ptr, (size_t)mask_low_half);
     uni_vmovups(vmm_mask_low_half, ptr[reg_ptr]);
 
-    mov(reg_local_wei_scales, ptr[rsp + reg_aux2_wei_scales_offs_]);
-
+    const int vec_size = vreg_traits<Vmm>::vlen;
+    auto accums_stack_space = bd_e * ld_block2 * vec_size;
+    sub(rsp, accums_stack_space);
     for (int bd = bd_b; bd < bd_e; bd++) {
         for (int ld = 0; ld < ld_block2; ld++) {
-            auto vmm_accm = vmm_accm_tmp(ld_block2, bd, ld);
+            auto vmm_accm = accm(ld_block2, bd, ld);
+            vmovups(ptr[rsp + (bd * ld_block2 + ld) * vec_size], vmm_accm);
+
             uni_vxorps(vmm_accm, vmm_accm, vmm_accm);
         }
     }
@@ -2480,48 +2433,83 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_dyn_quant(dim_t bd_block2,
                             have_to_load_bytes && bd_by_load_bytes, brg.dt_a);
             }
             if (prefetch_count_B < ld_block2) {
+                int typesize_scale = brg.dt_b == data_type::u4 ? 2 : 1;
                 prefetcht0(ptr[reg_aux_B + B_offset(prefetch_count_B++, rd)
-                        + brg.LDB * brg.rd_block * brg.typesize_B]);
+                        + brg.LDB * brg.rd_block * brg.typesize_B / typesize_scale]);
             }
             for (int ld = 0; ld < ld_block2; ld++) {
-                auto vmm = vmm_accm_tmp(ld_block2, bd, ld);
+                auto vmm = accm(ld_block2, bd, ld);
                 vpdpbusd(vmm, load(ld), bcst(), is_superset(brg.isa_impl, avx512_core) ? EvexEncoding : VexEncoding);
-            }
-            if (brg.with_wei_decomp_zero_points) {
-                uni_vpxor(bcst(), bcst(), vmm_neg_one);
-                uni_vpsubb(bcst(), bcst(), vmm_neg_one);
-                for (int ld = 0; ld < ld_block2; ld++) {
-                    auto vmm =  vmm_accm_tmp(ld_block2, bd, ld);
-                    Vmm vmm_zp = brg.wei_decomp_zero_points_stride == 0 ? vmm_zero_point(0) : vmm_zero_point(ld);
-                    vpdpbusd(vmm, vmm_zp, bcst(), is_superset(brg.isa_impl, avx512_core) ? EvexEncoding : VexEncoding);
-                }
             }
         }
     }
 
-    auto reg_local_src_scales = reg_local_wei_zp;
+    auto vmm_zero_point = [&](int ld) {
+        return load(ld);
+    };
+
+    auto reg_local_wei_zp = reg_ldb_loop;
+    auto reg_local_src_grouped_sum = reg_bdb_loop;
+    auto vmm_tmp = Vmm(isa_num_vregs(brg.isa_impl) - 1);
+    auto vmm_src_grouped_sum = bcst();
+
+    if (brg.with_wei_decomp_zero_points) {
+        mov(reg_local_wei_zp, ptr[rsp + reg_aux2_wei_zero_points_offs_ + accums_stack_space]);
+        if (brg.wei_decomp_zero_points_stride == 0) {
+            Vmm vmm_zp = vmm_zero_point(0);
+            auto reg_ptr_32 = Reg32(reg_ptr.getIdx());
+            movzx(reg_ptr_32, ptr[reg_local_wei_zp]);
+            uni_vmovq(Xmm(vmm_zp.getIdx()), reg_ptr);
+            uni_vbroadcastss(vmm_zp, Xmm(vmm_zp.getIdx()));
+        }
+
+        mov(reg_local_src_grouped_sum, ptr[rsp + reg_aux2_src_grouped_sum_offs_ + accums_stack_space]);
+        for (int bd = bd_b; bd < bd_e; bd++) {
+            uni_vbroadcastss(vmm_src_grouped_sum, ptr[reg_local_src_grouped_sum + bd * brg.src_grouped_sum_stride * sizeof(int32_t)]);
+            for (int ld = 0; ld < ld_block2; ld++) {
+                Vmm vmm_zp = brg.wei_decomp_zero_points_stride == 0 ? vmm_zero_point(0) : vmm_zero_point(ld);
+                if (bd == bd_b && brg.wei_decomp_zero_points_stride != 0) {
+                    uni_vpmovzxbd(vmm_zp, ptr[reg_local_wei_zp + ld * brg.ld_block * types::data_type_size(brg.wei_decomp_zero_points_dt)]);
+                }
+
+                auto vmm_accm = accm(ld_block2, bd, ld);
+                uni_vpmulld(vmm_tmp, vmm_src_grouped_sum, vmm_zp);
+                uni_vpsubd(vmm_accm, vmm_accm, vmm_tmp);
+            }
+        }
+    }
+
+    auto wei_scale = [&](int ld) {
+        return load(ld);
+    };
+
+    auto reg_local_src_scales = reg_ldb_loop;
+    auto reg_local_wei_scales = reg_bdb_loop;
     auto vmm_src_scales = bcst();
-    mov(reg_local_src_scales, ptr[rsp + reg_aux2_src_scales_offs_]);
+
+    mov(reg_local_wei_scales, ptr[rsp + reg_aux2_wei_scales_offs_ + accums_stack_space]);
+    mov(reg_local_src_scales, ptr[rsp + reg_aux2_src_scales_offs_ + accums_stack_space]);
+    if (brg.wei_decomp_scales_stride == 0) {
+        uni_vbroadcastss(wei_scale(0), ptr[reg_local_wei_scales]);
+    }
 
     for (int bd = bd_b; bd < bd_e; bd++) {
         uni_vbroadcastss(vmm_src_scales, ptr[reg_local_src_scales + bd * brg.src_scales_stride * sizeof(float)]);
         for (int ld = 0; ld < ld_block2; ld++) {
-            if (brg.wei_decomp_scales_stride == 0) {
-                uni_vbroadcastss(load(ld), ptr[reg_local_wei_scales]);
-            } else {
-                uni_vmovups(load(ld), ptr[reg_local_wei_scales + ld * brg.ld_block * sizeof(float)]);
+            auto vmm_wei_scale = brg.wei_decomp_scales_stride == 0 ? wei_scale(0) : wei_scale(ld);
+            if (bd == bd_b && brg.wei_decomp_scales_stride != 0) {
+                uni_vmovups(vmm_wei_scale, ptr[reg_local_wei_scales + ld * brg.ld_block * sizeof(float)]);
             }
-        }
-        for (int ld = 0; ld < ld_block2; ld++) {
-            auto vmm_accm_aux = vmm_accm_tmp(ld_block2, bd, ld);
-            auto vmm_accm = accm(ld_block2, bd, ld);
 
-            uni_vcvtdq2ps(vmm_accm_aux, vmm_accm_aux);
-            uni_vmulps(vmm_accm_aux, vmm_accm_aux, vmm_src_scales);
-            uni_vfmadd231ps(vmm_accm, vmm_accm_aux, load(ld));
+            auto vmm_accm = accm(ld_block2, bd, ld);
+            uni_vcvtdq2ps(vmm_accm, vmm_accm);
+            uni_vmulps(vmm_tmp, vmm_accm, vmm_src_scales);
+            uni_vmovups(vmm_accm, ptr[rsp + (bd * ld_block2 + ld) * vec_size]);
+            uni_vfmadd231ps(vmm_accm, vmm_tmp, vmm_wei_scale);
         }
     }
 
+    add(rsp, accums_stack_space);
     mov(reg_ldb_loop, ptr[rsp + reg_ldb_loop_offs_]);
     mov(reg_bdb_loop, ptr[rsp + reg_bdb_loop_offs_]);
 
@@ -3038,6 +3026,98 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(dim_t bd_block2, bool is_bdb_tail,
         dim_t ld_block2, dim_t ldb_loop_length, bool is_reg_tail,
         bool is_ld_tail, bool first_bdb, bool last_bdb, dim_t rows_for_rd_tail,
         bool skip_accumulation) {
+    auto ic_group_shift_generic = [&]() {
+        if ((brg.with_grouped_wei_decomp && (brg.wei_decomp_scales_stride != 0 || brg.wei_decomp_zero_points_stride != 0))
+                || brg.with_src_dyn_quant) {
+            auto reg_local_ic = reg_aux_D;
+            auto reg_local_wei_params = reg_bdb_loop;
+            auto reg_local_ic_group = reg_ldb_loop;
+
+            auto ic_group_shift = [&](int src_offs, int dst_offs, int group_size, int stride) {
+                mov(reg_local_ic, ptr[rsp + reg_aux_ic_offs_]);
+                mov(reg_local_ic_group, group_size);
+                xor_(rdx, rdx);
+                idiv(reg_local_ic_group);
+                imul(reg_local_ic, reg_local_ic, stride);
+
+                mov(reg_local_wei_params, ptr[rsp + src_offs]);
+                add(reg_local_wei_params, reg_local_ic);
+                mov(ptr[rsp + dst_offs], reg_local_wei_params);
+            };
+
+            mov(ptr[rsp + reg_bdb_loop_offs_], reg_bdb_loop);
+            mov(ptr[rsp + reg_aux2_D_offs_], reg_aux_D);
+            mov(ptr[rsp + reg_ldb_loop_offs_], reg_ldb_loop);
+            mov(ptr[rsp + reg_reg_a_offset_offs_], reg_a_offset); // preserve rdx for idiv
+
+            if (brg.with_wei_decomp_scales && brg.wei_decomp_scales_stride != 0) {
+                ic_group_shift(reg_aux_wei_scales_offs_, reg_aux2_wei_scales_offs_,
+                                brg.wei_decomp_scales_group_size, brg.wei_decomp_scales_stride * types::data_type_size(brg.wei_decomp_scales_dt));
+            }
+
+            if (brg.with_wei_decomp_zero_points && brg.wei_decomp_zero_points_stride != 0) {
+                ic_group_shift(reg_aux_wei_zero_points_offs_, reg_aux2_wei_zero_points_offs_,
+                                brg.wei_decomp_zero_points_group_size, brg.wei_decomp_zero_points_stride * types::data_type_size(brg.wei_decomp_zero_points_dt));
+            }
+
+            if (brg.with_src_dyn_quant) {
+                ic_group_shift(reg_aux_src_scales_offs_, reg_aux2_src_scales_offs_,
+                                brg.src_scales_group_size, sizeof(float));
+
+                if (brg.with_wei_decomp_zero_points) {
+                    ic_group_shift(reg_aux_src_grouped_sum_offs_, reg_aux2_src_grouped_sum_offs_,
+                                brg.src_sum_group_size, sizeof(int32_t));
+                }
+            }
+
+            mov(reg_local_ic, ptr[rsp + reg_aux_ic_offs_]);
+            add(reg_local_ic, brg.rd_block);
+            mov(ptr[rsp + reg_aux_ic_offs_], reg_local_ic);
+
+            mov(reg_bdb_loop, ptr[rsp + reg_bdb_loop_offs_]);
+            mov(reg_aux_D, ptr[rsp + reg_aux2_D_offs_]);
+            mov(reg_ldb_loop, ptr[rsp + reg_ldb_loop_offs_]);
+            mov(reg_a_offset, ptr[rsp + reg_reg_a_offset_offs_]);
+        }
+    };
+
+    auto ic_group_shift_opt = [&](int rb) {
+        if ((brg.with_grouped_wei_decomp && (brg.wei_decomp_scales_stride != 0 || brg.wei_decomp_zero_points_stride != 0))
+                || brg.with_src_dyn_quant) {
+            mov(ptr[rsp + reg_bdb_loop_offs_], reg_rdb_loop);
+            auto reg_ptr = reg_rdb_loop;
+
+            auto ic_group_shift = [&](int src_offs, int dst_offs, int group_size, int stride) {
+                if ((rb + 1) * brg.rd_block % group_size == 0) {
+                    mov(reg_ptr, ptr[rsp + src_offs]);
+                    add(reg_ptr, stride);
+                    mov(ptr[rsp + dst_offs], reg_ptr);
+                }
+            };
+
+            if (brg.with_wei_decomp_scales && brg.wei_decomp_scales_stride != 0) {
+                ic_group_shift(reg_aux2_wei_scales_offs_, reg_aux2_wei_scales_offs_,
+                                brg.wei_decomp_scales_group_size, brg.wei_decomp_scales_stride * types::data_type_size(brg.wei_decomp_scales_dt));
+            }
+
+            if (brg.with_wei_decomp_zero_points && brg.wei_decomp_zero_points_stride != 0) {
+                ic_group_shift(reg_aux2_wei_zero_points_offs_, reg_aux2_wei_zero_points_offs_,
+                                brg.wei_decomp_zero_points_group_size, brg.wei_decomp_zero_points_stride * types::data_type_size(brg.wei_decomp_zero_points_dt));
+            }
+
+            if (brg.with_src_dyn_quant) {
+                ic_group_shift(reg_aux2_src_scales_offs_, reg_aux2_src_scales_offs_,
+                                brg.src_scales_group_size, sizeof(float));
+
+                if (brg.with_wei_decomp_zero_points) {
+                    ic_group_shift(reg_aux2_src_grouped_sum_offs_, reg_aux2_src_grouped_sum_offs_,
+                                brg.src_sum_group_size, sizeof(int32_t));
+                }
+            }
+
+            mov(reg_rdb_loop, ptr[rsp + reg_bdb_loop_offs_]);
+        }
+    };
 
     Label ldb_loop_label;
     Label BS_loop_label;
@@ -3045,6 +3125,11 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(dim_t bd_block2, bool is_bdb_tail,
     copy_post_ops_stack_values_to_aux(is_reg_tail);
 
     auto ld_loop_body = [&](dim_t vpad, bool last_bdb) {
+        if (brg.with_grouped_wei_decomp) {
+            mov(reg_ic, ptr[rsp + reg_ic_offs_]);
+            mov(ptr[rsp + reg_aux_ic_offs_], reg_ic);
+        }
+
         set_A_B_matrices();
 
         dim_t bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
@@ -3059,70 +3144,77 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(dim_t bd_block2, bool is_bdb_tail,
             gemm_microkernel_amx(bd_block2, is_bdb_tail, ld_block2, is_rd_tail,
                     is_ld_tail, last_bdb);
         } else {
-            if (brg.rdb > 0) {
-                Label rdb_loop_label;
-                mov(reg_rdb_loop, brg.rdb);
-                L_aligned(rdb_loop_label, 64);
-                {
-                    if ((brg.with_grouped_wei_decomp && (brg.wei_decomp_scales_stride != 0 ||
-                                                        brg.wei_decomp_zero_points_stride != 0)) || brg.with_src_dyn_quant) {
-                        auto reg_local_ic = reg_aux_D;
-                        auto reg_local_wei_params = reg_bdb_loop;
-                        auto reg_local_ic_group = reg_ldb_loop;
+            ic_group_shift_generic();
 
-                        auto ic_group_shift = [&](int src_offs, int dst_offs, int group_size, int stride) {
-                            mov(reg_local_ic, ptr[rsp + reg_aux_ic_offs_]);
-                            mov(reg_local_ic_group, group_size);
-                            xor_(rdx, rdx);
-                            idiv(reg_local_ic_group);
-                            imul(reg_local_ic, reg_local_ic, stride);
+            auto rdb_group = brg.rd_block;
+            auto rd_size = brg.rdb * brg.rd_block + brg.rdb_tail;
+            if (brg.wei_decomp_scales_group_size < rd_size)
+                rdb_group = nstl::max(rdb_group, brg.wei_decomp_scales_group_size);
+            if (brg.wei_decomp_zero_points_group_size < rd_size)
+                rdb_group = nstl::max(rdb_group, brg.wei_decomp_zero_points_group_size);
+            if (brg.with_src_dyn_quant) {
+                rdb_group = nstl::max(rdb_group, brg.src_scales_group_size);
+                if (brg.with_wei_decomp_zero_points) {
+                    rdb_group = nstl::max(rdb_group, brg.src_sum_group_size);
+                }
+            }
+            rdb_group = rdb_group / brg.rd_block;
+            auto rbd_blocks = brg.rdb / rdb_group;
+            auto max_rdb_unroll = 8;
 
-                            mov(reg_local_wei_params, ptr[rsp + src_offs]);
-                            add(reg_local_wei_params, reg_local_ic);
-                            mov(ptr[rsp + dst_offs], reg_local_wei_params);
-                        };
+            if (brg.with_wei_decomp && rdb_group <= max_rdb_unroll) {
+                if (rbd_blocks > 0) {
+                    Label rdb_loop_label;
+                    mov(reg_rdb_loop, rbd_blocks);
+                    L_aligned(rdb_loop_label, 64);
+                    {
+                        for (int rb = 0; rb < rdb_group; rb++) {
+                            gemm_microkernel(bd_block2, is_bdb_tail, ld_block2, false,
+                                    is_ld_tail, vpad, rows_for_rd_tail);
 
-                        mov(ptr[rsp + reg_bdb_loop_offs_], reg_bdb_loop);
-                        mov(ptr[rsp + reg_aux2_D_offs_], reg_aux_D);
-                        mov(ptr[rsp + reg_ldb_loop_offs_], reg_ldb_loop);
-                        mov(ptr[rsp + reg_reg_a_offset_offs_], reg_a_offset); // preserve rdx for idiv
+                            add(reg_aux_A, rdb_A_offset());
+                            add(reg_aux_B, rdb_B_offset());
 
-                        if (brg.with_wei_decomp_scales && brg.wei_decomp_scales_stride != 0) {
-                            ic_group_shift(reg_aux_wei_scales_offs_, reg_aux2_wei_scales_offs_,
-                                           brg.wei_decomp_scales_group_size, brg.wei_decomp_scales_stride * types::data_type_size(brg.wei_decomp_scales_dt));
+                            ic_group_shift_opt(rb);
                         }
 
-                        if (brg.with_wei_decomp_zero_points && brg.wei_decomp_zero_points_stride != 0) {
-                            ic_group_shift(reg_aux_wei_zero_points_offs_, reg_aux2_wei_zero_points_offs_,
-                                           brg.wei_decomp_zero_points_group_size, brg.wei_decomp_zero_points_stride * types::data_type_size(brg.wei_decomp_zero_points_dt));
-                        }
-
-                        if (brg.with_src_dyn_quant) {
-                            ic_group_shift(reg_aux_src_scales_offs_, reg_aux2_src_scales_offs_,
-                                           brg.src_scales_group_size, sizeof(float));
-                        }
-
-                        mov(reg_local_ic, ptr[rsp + reg_aux_ic_offs_]);
-                        add(reg_local_ic, brg.rd_block);
-                        mov(ptr[rsp + reg_aux_ic_offs_], reg_local_ic);
-
-                        mov(reg_bdb_loop, ptr[rsp + reg_bdb_loop_offs_]);
-                        mov(reg_aux_D, ptr[rsp + reg_aux2_D_offs_]);
-                        mov(reg_ldb_loop, ptr[rsp + reg_ldb_loop_offs_]);
-                        mov(reg_a_offset, ptr[rsp + reg_reg_a_offset_offs_]);
+                        dec(reg_rdb_loop);
+                        cmp(reg_rdb_loop, 0);
                     }
+                    jg(rdb_loop_label, T_NEAR);
+                }
 
-                    const bool is_rd_tail = false;
-                    gemm_microkernel(bd_block2, is_bdb_tail, ld_block2,
-                            is_rd_tail, is_ld_tail, vpad, rows_for_rd_tail);
+                for (int rb = rbd_blocks * rdb_group; rb < brg.rdb; rb++) {
+                    gemm_microkernel(bd_block2, is_bdb_tail, ld_block2, false,
+                            is_ld_tail, vpad, rows_for_rd_tail);
 
                     add(reg_aux_A, rdb_A_offset());
                     add(reg_aux_B, rdb_B_offset());
 
-                    dec(reg_rdb_loop);
-                    cmp(reg_rdb_loop, 0);
+                    ic_group_shift_opt(rb);
+
+                    mov(reg_rdb_loop, ptr[rsp + reg_bdb_loop_offs_]);
                 }
-                jg(rdb_loop_label, T_NEAR);
+            } else {
+                if (brg.rdb > 0) {
+                    Label rdb_loop_label;
+                    mov(reg_rdb_loop, brg.rdb);
+                    L_aligned(rdb_loop_label, 64);
+                    {
+                        const bool is_rd_tail = false;
+                        gemm_microkernel(bd_block2, is_bdb_tail, ld_block2,
+                                is_rd_tail, is_ld_tail, vpad, rows_for_rd_tail);
+
+                        add(reg_aux_A, rdb_A_offset());
+                        add(reg_aux_B, rdb_B_offset());
+
+                        ic_group_shift_generic();
+
+                        dec(reg_rdb_loop);
+                        cmp(reg_rdb_loop, 0);
+                    }
+                    jg(rdb_loop_label, T_NEAR);
+                }
             }
         }
         if (brg.rdb_tail != 0) {

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2391,7 +2391,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_dyn_quant(dim_t bd_block2,
     mov(reg_ptr, (size_t)mask_low_half);
     uni_vmovups(vmm_mask_low_half, ptr[reg_ptr]);
 
-    const int vec_size = vreg_traits<Vmm>::vlen;
+    const int vec_size = vreg_traits_t<Vmm>::vlen;
     auto accums_stack_space = bd_e * ld_block2 * vec_size;
     sub(rsp, accums_stack_space);
     for (int bd = bd_b; bd < bd_e; bd++) {
@@ -3411,6 +3411,10 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
                       mov(reg_src_scales, ptr[rsp + reg_src_scales_offs_]);
                       add(reg_src_scales, bd_block2 * brg.bd_block * brg.src_scales_stride * sizeof(float));
                       mov(ptr[rsp + reg_src_scales_offs_], reg_src_scales);
+
+                      mov(reg_src_grouped_sum, ptr[rsp + reg_src_grouped_sum_offs_]);
+                      add(reg_src_grouped_sum, bd_block2 * brg.bd_block * brg.src_grouped_sum_stride * sizeof(int32_t));
+                      mov(ptr[rsp + reg_src_grouped_sum_offs_], reg_src_grouped_sum);
                   }
 
                   advance_bd_block2_post_op_regs(bd_block2);

--- a/src/cpu/x64/jit_brgemm_inner_product.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.cpp
@@ -142,21 +142,26 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
 
     int8_t* qsrc = nullptr;
     float* src_dscales = nullptr;
+    int32_t* src_grouped_sum = nullptr;
     if (jbgp.with_src_dynamic_quant) {
         qsrc = scratchpad.template get<int8_t>(key_src_quantized);
         src_dscales = scratchpad.template get<float>(key_src_dequantized_scales);
+        src_grouped_sum = scratchpad.template get<int32_t>(key_src_grouped_sum);
 
         int ic_groups = div_up(jbgp.ic, jbgp.src_quant_group_size);
+        int ic_sum_groups = div_up(jbgp.ic, jbgp.src_sum_group_size);
         auto src_ptr = reinterpret_cast<const float*>(src);
         auto qsrc_ptr = qsrc;
         auto src_dscales_ptr = src_dscales;
-        int vec_loop_end = (ic_groups - 1) * jbgp.src_quant_group_size;
+        auto src_grouped_sum_ptr = src_grouped_sum;
+        int vec_loop_end = rnd_dn(jbgp.ic, jbgp.src_quant_group_size);
 
         parallel_nd(jbgp.mb, [&](int mb) {
             src_quantization_runtime_params_t rt_params = {};
             rt_params.src_ptr = src_ptr + mb * jbgp.ic;
             rt_params.qsrc_ptr = qsrc_ptr + mb * jbgp.ic;
             rt_params.src_scales_ptr = src_dscales_ptr + mb * ic_groups;
+            rt_params.src_grouped_sum_ptr = src_grouped_sum_ptr + mb * ic_sum_groups;
             rt_params.ic_size = vec_loop_end;
             (*brg_src_quant_kernel_)(&rt_params);
 
@@ -172,6 +177,18 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
                 src_dscales_ptr[mb * ic_groups + ic_groups - 1] = dscale;
                 for (int ic = vec_loop_end; ic < jbgp.ic; ic++) {
                     qsrc_ptr[mb * jbgp.ic + ic] = std::round(src_ptr[mb * jbgp.ic + ic] * qscale);
+                }
+            }
+
+            if (jbgp.wei_decomp_zero_points_dt) {
+                for (int icb = vec_loop_end / jbgp.src_quant_group_size; icb < ic_sum_groups; icb++) {
+                    int ic_begin = icb * jbgp.src_sum_group_size;
+                    int ic_end = nstl::min(static_cast<int>((icb + 1) * jbgp.src_sum_group_size), jbgp.ic);
+                    int sum = 0;
+                    for (int ic = ic_begin; ic < ic_end; ic++) {
+                        sum += qsrc_ptr[mb * jbgp.ic + ic];
+                    }
+                    src_grouped_sum_ptr[mb * ic_sum_groups + icb] = sum;
                 }
             }
         });
@@ -428,10 +445,12 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
             int wei_scales_offset = 0;
             int wei_zero_points_offset = 0;
             int src_scales_offset = 0;
+            int src_grouped_sum_offset = 0;
             if (jbgp.weights_decompression) {
                 wei_scales_offset = wei_scales_oc_stride * oc * wei_scales_dt_size;
                 wei_zero_points_offset = wei_zero_points_oc_stride * oc * wei_zero_points_dt_size;
                 src_scales_offset = n * div_up(jbgp.ic, jbgp.src_quant_group_size);
+                src_grouped_sum_offset = n * div_up(jbgp.ic, jbgp.src_sum_group_size);
             }
 
             auto ptr_D = dst + dst_off;
@@ -455,10 +474,12 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
 
                 brgemm_kernel_execute_postops(brg_kernel, gemm_batch,
                         addr_batch, (void *)ptr_C, (void *)ptr_D, post_ops_data,
-                        scratch, nullptr, wei_scales + wei_scales_offset, wei_zero_points + wei_zero_points_offset, src_dscales + src_scales_offset, ic);
+                        scratch, nullptr, wei_scales + wei_scales_offset, wei_zero_points + wei_zero_points_offset,
+                        src_dscales + src_scales_offset, src_grouped_sum + src_grouped_sum_offset, ic);
             } else {
                 brgemm_kernel_execute(brg_kernel, gemm_batch, addr_batch,
-                        (void *)ptr_C, is_amx ? (void *)wsp_tile : nullptr, nullptr, wei_scales + wei_scales_offset, wei_zero_points + wei_zero_points_offset, src_dscales + src_scales_offset, ic);
+                        (void *)ptr_C, is_amx ? (void *)wsp_tile : nullptr, nullptr, wei_scales + wei_scales_offset, wei_zero_points + wei_zero_points_offset,
+                        src_dscales + src_scales_offset, src_grouped_sum + src_grouped_sum_offset, ic);
             }
         }
 
@@ -533,10 +554,12 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
             int wei_scales_offset = 0;
             int wei_zero_points_offset = 0;
             int src_scales_offset = 0;
+            int src_grouped_sum_offset = 0;
             if (jbgp.weights_decompression) {
                 wei_scales_offset = wei_scales_oc_stride * oc * wei_scales_dt_size;
                 wei_zero_points_offset = wei_zero_points_oc_stride * oc * wei_zero_points_dt_size;
                 src_scales_offset = n * div_up(jbgp.ic, jbgp.src_quant_group_size);
+                src_grouped_sum_offset = n * div_up(jbgp.ic, jbgp.src_sum_group_size);
             }
 
             auto brg_kernel_ic_tail = brg_kernels_[brg_ker_ic_tail_idx].get();
@@ -559,10 +582,12 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
                         nullptr, false, 1, false, false, dst_scales};
 
                 brgemm_kernel_execute_postops(brg_kernel_ic_tail, 1, addr_batch,
-                        (void *)ptr_C, (void *)ptr_D, post_ops_data, scratch, nullptr, wei_scales + wei_scales_offset, wei_zero_points + wei_zero_points_offset, src_dscales + src_scales_offset, ic);
+                        (void *)ptr_C, (void *)ptr_D, post_ops_data, scratch, nullptr, wei_scales + wei_scales_offset, wei_zero_points + wei_zero_points_offset,
+                        src_dscales + src_scales_offset, src_grouped_sum + src_grouped_sum_offset, ic);
             } else {
                 brgemm_kernel_execute(brg_kernel_ic_tail, 1, addr_batch,
-                        (void *)ptr_C, is_amx ? (void *)wsp_tile : nullptr, nullptr, wei_scales + wei_scales_offset, wei_zero_points + wei_zero_points_offset, src_dscales + src_scales_offset, ic);
+                        (void *)ptr_C, is_amx ? (void *)wsp_tile : nullptr, nullptr, wei_scales + wei_scales_offset, wei_zero_points + wei_zero_points_offset,
+                        src_dscales + src_scales_offset, src_grouped_sum + src_grouped_sum_offset, ic);
             }
         }
     };

--- a/src/cpu/x64/jit_brgemm_inner_product.hpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.hpp
@@ -269,6 +269,8 @@ struct brgemm_inner_product_fwd_t : public primitive_t {
         if (pd()->jbgp_.with_src_dynamic_quant) {
             src_quantization_compile_params_t jcp = {};
             jcp.ic_quant_block = pd()->jbgp_.src_quant_group_size;
+            jcp.with_src_grouped_sum = !pd()->attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS);
+            jcp.src_sum_group_size = pd()->jbgp_.src_sum_group_size;
             jcp.src_dt = pd()->jbgp_.orig_src_dt;
             jcp.qsrc_dt = data_type::s8;
 

--- a/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
@@ -706,6 +706,7 @@ status_t jit_brgemm_ip_fwd_conf_t::init_conf(cpu_isa_t isa,
         if (jbgp.wei_zero_points_ic_group_size != static_cast<size_t>(jbgp.ic))
             max_ic_group_size = std::max(max_ic_group_size, jbgp.wei_zero_points_ic_group_size);
         max_ic_group_size = std::max(max_ic_group_size, jbgp.src_quant_group_size);
+        max_ic_group_size = std::max(max_ic_group_size, jbgp.src_sum_group_size);
 
         if ((jbgp.nb_ic_blocking * k_blk) % max_ic_group_size != 0) {
             jbgp.nb_ic_blocking = max_ic_group_size;
@@ -1435,6 +1436,7 @@ status_t jit_brgemm_ip_conf_t::init_conf_base(cpu_isa_t isa,
     jbgp.with_src_dynamic_quant = false;
     if (jbgp.weights_decompression) {
         jbgp.src_quant_group_size = jbgp.ic;
+        jbgp.src_sum_group_size = jbgp.ic;
         if (!attr.src_dyn_quant_params_.has_default_values()) {
             jbgp.with_src_dynamic_quant = true;
         }
@@ -1453,11 +1455,6 @@ status_t jit_brgemm_ip_conf_t::init_conf_base(cpu_isa_t isa,
             if (attr.zero_points_.get_dims(DNNL_ARG_WEIGHTS)[1] != 1) {
                 jbgp.with_grouped_weights_decompression = true;
                 jbgp.wei_zero_points_ic_group_size = div_up(jbgp.ic, attr.zero_points_.get_dims(DNNL_ARG_WEIGHTS)[1]);
-            }
-
-            // todo: fix avx2 brgemm kernel behavior for non scalar zp
-            if (!is_superset(isa, avx512_core) && attr.zero_points_.get_dims(DNNL_ARG_WEIGHTS)[0] != 1) {
-                jbgp.with_src_dynamic_quant = false;
             }
 
             jbgp.wei_decomp_zero_points_dt = attr.zero_points_.get_data_type(DNNL_ARG_WEIGHTS);
@@ -1481,6 +1478,12 @@ status_t jit_brgemm_ip_conf_t::init_conf_base(cpu_isa_t isa,
         if (jbgp.is_amx && jbgp.wei_decomp_algo == weights_decomp_kind_t::immediate)
             return status::unimplemented;
 
+        auto min_group_size = nstl::min(jbgp.wei_scales_ic_group_size, jbgp.wei_zero_points_ic_group_size);
+        if (jbgp.wei_scales_ic_group_size % min_group_size)
+            return status::unimplemented;
+        if (jbgp.wei_zero_points_ic_group_size % min_group_size)
+            return status::unimplemented;
+
         if (jbgp.with_src_dynamic_quant) {
             if (!(one_of(jbgp.wei_dt, u4, u8) &&
                   one_of(jbgp.wei_decomp_scales_dt, f32) &&
@@ -1490,12 +1493,20 @@ status_t jit_brgemm_ip_conf_t::init_conf_base(cpu_isa_t isa,
             const size_t simd_width = 16;
             if (jbgp.src_quant_group_size == 0 || jbgp.src_quant_group_size % simd_width)
                 return status::unimplemented;
-        }
-    }
 
-    if (jbgp.with_src_dynamic_quant) {
-        jbgp.orig_src_dt = jbgp.src_dt;
-        jbgp.src_dt = s8;
+            jbgp.orig_src_dt = jbgp.src_dt;
+            jbgp.src_dt = s8;
+
+            size_t rd_unroll = jbgp.src_quant_group_size;
+            jbgp.src_sum_group_size = nstl::min(rd_unroll, min_group_size);
+
+            if (jbgp.wei_scales_ic_group_size != static_cast<size_t>(jbgp.ic) && jbgp.wei_scales_ic_group_size % jbgp.src_sum_group_size)
+                return status::unimplemented;
+            if (jbgp.wei_zero_points_ic_group_size != static_cast<size_t>(jbgp.ic) && jbgp.wei_zero_points_ic_group_size % jbgp.src_sum_group_size)
+                return status::unimplemented;
+            if (jbgp.src_quant_group_size % jbgp.src_sum_group_size)
+                return status::unimplemented;
+        }
     }
 
     jbgp.bia_dt = jbgp.with_bias
@@ -1727,6 +1738,8 @@ void jit_brgemm_ip_conf_t::init_scratchpad_base(
     if (jbgp.with_src_dynamic_quant) {
         scratchpad.book(key_src_quantized, jbgp.mb * jbgp.ic, sizeof(int8_t));
         scratchpad.book(key_src_dequantized_scales, jbgp.mb * div_up(jbgp.ic, jbgp.src_quant_group_size), sizeof(float));
+        if (jbgp.wei_decomp_zero_points_dt)
+            scratchpad.book(key_src_grouped_sum, jbgp.mb * div_up(jbgp.ic, jbgp.src_sum_group_size), sizeof(int32_t));
     }
 }
 

--- a/src/cpu/x64/jit_brgemm_primitive_conf.hpp
+++ b/src/cpu/x64/jit_brgemm_primitive_conf.hpp
@@ -113,6 +113,7 @@ struct jit_brgemm_primitive_conf_t {
 
     bool with_src_dynamic_quant;
     size_t src_quant_group_size;
+    size_t src_sum_group_size;
     data_type_t orig_src_dt;
 };
 

--- a/src/cpu/x64/jit_brgemm_src_quantization_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_src_quantization_kernel.cpp
@@ -44,12 +44,46 @@ void jit_brgemm_src_quantization_kernel_t<isa>::load_src(Vmm vmm_load, const Xby
 }
 
 template <cpu_isa_t isa>
+void jit_brgemm_src_quantization_kernel_t<isa>::horiz_op(Vmm vmm_src, Vmm vmm_aux, op_type type) {
+    auto uni_op = [&](const Xbyak::Ymm &x1, const Xbyak::Ymm &x2, const Xbyak::Operand &op) {
+        if (type == op_type::max) {
+            uni_vmaxps(x1, x2, op);
+        } else if (type == op_type::sum) {
+            uni_vpaddd(x1, x2, op);
+        } else {
+            assert(!"unsupported op type");
+        }
+    };
+
+    if (isa == avx512_core) {
+        Xbyak::Zmm zmm_src = Xbyak::Zmm(vmm_src.getIdx());
+        Xbyak::Zmm zmm_aux = Xbyak::Zmm(vmm_aux.getIdx());
+        vshuff32x4(zmm_aux, zmm_src, zmm_src, 0x4E);
+        uni_op(zmm_src, zmm_src, zmm_aux);
+        vshuff32x4(zmm_aux, zmm_src, zmm_src, 0xB1);
+        uni_op(zmm_src, zmm_src, zmm_aux);
+    } else if (isa == avx2) {
+        Xbyak::Ymm ymm_src = Xbyak::Ymm(vmm_src.getIdx());
+        Xbyak::Ymm ymm_aux = Xbyak::Ymm(vmm_aux.getIdx());
+        vperm2i128(ymm_aux, ymm_src, ymm_src, 0x01);
+        uni_op(ymm_src, ymm_src, ymm_aux);
+    } else {
+        assert(!"unsupported isa");
+    }
+    uni_vshufps(vmm_aux, vmm_src, vmm_src, 0x4E);
+    uni_op(vmm_src, vmm_src, vmm_aux);
+    uni_vshufps(vmm_aux, vmm_src, vmm_src, 0xB1);
+    uni_op(vmm_src, vmm_src, vmm_aux);
+}
+
+template <cpu_isa_t isa>
 void jit_brgemm_src_quantization_kernel_t<isa>::generate() {
     preamble();
 
     mov(reg_src, ptr[param1 + GET_OFF(src_ptr)]);
     mov(reg_qsrc, ptr[param1 + GET_OFF(qsrc_ptr)]);
     mov(reg_src_scales, ptr[param1 + GET_OFF(src_scales_ptr)]);
+    mov(reg_src_grouped_sum, ptr[param1 + GET_OFF(src_grouped_sum_ptr)]);
     mov(reg_ic_size, ptr[param1 + GET_OFF(ic_size)]);
 
     Xbyak::Label ic_loop_label;
@@ -58,6 +92,7 @@ void jit_brgemm_src_quantization_kernel_t<isa>::generate() {
     size_t src_dt_size = types::data_type_size(jcp_.src_dt);
     size_t qsrc_dt_size = types::data_type_size(jcp_.qsrc_dt);
     size_t src_scales_dt_size = types::data_type_size(data_type::f32);
+    size_t src_grouped_sum_dt_size = types::data_type_size(data_type::s32);
 
     static const float negative_zero[16] = {
         -0.f, -0.f, -0.f, -0.f, -0.f, -0.f, -0.f, -0.f,
@@ -89,6 +124,7 @@ void jit_brgemm_src_quantization_kernel_t<isa>::generate() {
         jl(ic_end_label, T_NEAR);
 
         assert(!(jcp_.ic_quant_block % vec_size));
+        assert(!(jcp_.src_sum_group_size % vec_size));
 
         int ic_blocks = jcp_.ic_quant_block / vec_size;
         uni_vpxor(vmm_max(), vmm_max(), vmm_max());
@@ -98,25 +134,7 @@ void jit_brgemm_src_quantization_kernel_t<isa>::generate() {
             uni_vmaxps(vmm_max(), vmm_max(), vmm_src());
         }
 
-        if (isa == avx512_core) {
-            Xbyak::Zmm max_zmm = Xbyak::Zmm(vmm_max().getIdx());
-            Xbyak::Zmm aux_zmm = Xbyak::Zmm(vmm_aux().getIdx());
-            vshuff32x4(aux_zmm, max_zmm, max_zmm, 0x4E);
-            uni_vmaxps(max_zmm, max_zmm, aux_zmm);
-            vshuff32x4(aux_zmm, max_zmm, max_zmm, 0xB1);
-            uni_vmaxps(max_zmm, max_zmm, aux_zmm);
-        } else if (isa == avx2) {
-            Xbyak::Ymm max_ymm = Xbyak::Ymm(vmm_max().getIdx());
-            Xbyak::Ymm aux_ymm = Xbyak::Ymm(vmm_aux().getIdx());
-            vperm2i128(aux_ymm, max_ymm, max_ymm, 0x01);
-            uni_vmaxps(max_ymm, max_ymm, aux_ymm);
-        } else {
-            assert(!"unsupported isa");
-        }
-        uni_vshufps(vmm_aux(), vmm_max(), vmm_max(), 0x4E);
-        uni_vmaxps(vmm_max(), vmm_max(), vmm_aux());
-        uni_vshufps(vmm_aux(), vmm_max(), vmm_max(), 0xB1);
-        uni_vmaxps(vmm_max(), vmm_max(), vmm_aux());
+        horiz_op(vmm_max(), vmm_aux(), op_type::max);
 
         auto vmm_dscale = vmm_max();
         uni_vbroadcastss(vmm_dscale, Xmm(vmm_dscale.getIdx()));
@@ -126,10 +144,24 @@ void jit_brgemm_src_quantization_kernel_t<isa>::generate() {
         uni_vdivps(vmm_qscale(), vmm_one(), vmm_dscale);
 
         uni_vmovss(ptr[reg_src_scales], Xmm(vmm_dscale.getIdx()));
+        if (jcp_.with_src_grouped_sum) {
+            uni_vxorps(vmm_src_sum_accum(), vmm_src_sum_accum(), vmm_src_sum_accum());
+        }
         for (int icb = 0; icb < ic_blocks; icb++) {
             load_src(vmm_src(), ptr[reg_src + icb * vec_size * src_dt_size]);
             uni_vmulps(vmm_src(), vmm_src(), vmm_qscale());
             uni_vcvtps2dq(vmm_src(), vmm_src());
+
+            if (jcp_.with_src_grouped_sum) {
+                uni_vpaddd(vmm_src_sum_accum(), vmm_src_sum_accum(), vmm_src());
+
+                if (((icb + 1) * vec_size) % jcp_.src_sum_group_size == 0) {
+                    horiz_op(vmm_src_sum_accum(), vmm_aux(), op_type::sum);
+                    uni_vmovss(ptr[reg_src_grouped_sum], Xmm(vmm_src_sum_accum().getIdx()));
+                    uni_vxorps(vmm_src_sum_accum(), vmm_src_sum_accum(), vmm_src_sum_accum());
+                    add(reg_src_grouped_sum, src_grouped_sum_dt_size);
+                }
+            }
 
             if (isa == avx512_core) {
                 vpmovsdb(ptr[reg_qsrc + icb * vec_size * qsrc_dt_size], vmm_src());

--- a/src/cpu/x64/jit_brgemm_src_quantization_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_src_quantization_kernel.hpp
@@ -32,6 +32,8 @@ namespace x64 {
 
 struct src_quantization_compile_params_t {
     size_t ic_quant_block;
+    bool with_src_grouped_sum;
+    size_t src_sum_group_size;
     data_type_t src_dt;
     data_type_t qsrc_dt;
 };
@@ -40,6 +42,7 @@ struct src_quantization_runtime_params_t {
     const void *src_ptr;
     const void *qsrc_ptr;
     const void *src_scales_ptr;
+    const void *src_grouped_sum_ptr;
     size_t ic_size;
 };
 
@@ -76,6 +79,9 @@ private:
     void generate() override;
     void load_src(Vmm vmm_load, const Xbyak::Address& addr);
 
+    enum class op_type {max, sum};
+    void horiz_op(Vmm vmm_src, Vmm vmm_aux, op_type op);
+
     Vmm vmm_src() {
         return Vmm(0);
     }
@@ -104,11 +110,16 @@ private:
         return Vmm(6);
     }
 
+    Vmm vmm_src_sum_accum() {
+        return Vmm(7);
+    }
+
     Xbyak::Reg64 reg_src = r8;
     Xbyak::Reg64 reg_qsrc = r9;
     Xbyak::Reg64 reg_src_scales = r10;
     Xbyak::Reg64 reg_ic_size = r11;
     Xbyak::Reg64 reg_tmp = r12;
+    Xbyak::Reg64 reg_src_grouped_sum = r13;
 
     size_t vec_size;
 };


### PR DESCRIPTION
# Description
fix below test after migration v3.8,
-smoke_MatMulCompressedWeights_non_default_d
-smoke_LPT_Convolution
-smoke_LPT_GroupConvolution


