### PR TITLE
[FORK][FIX] fix crash of convolution 1x1 int8 model on SPR

### DIFF
--- a/src/cpu/x64/brgemm/brgemm_containers.cpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.cpp
@@ -49,6 +49,10 @@ bool brgemm_desc_container_t::insert(int idx, brgemm_desc_t &brg,
     brg.brgattr.static_offsets = static_offsets_list_.back().data();
 
     const auto ret = map_.insert({brg, idx});
+    const int ref_size = refs_.size();
+    if (idx > ref_size - 1) {
+        refs_.resize(idx + 1);
+    }
     refs_[idx] = &(ret.first->first);
     // if there was no insertion then clean bd_mask and static_offsets
     if (!ret.second) {

--- a/src/cpu/x64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.hpp
@@ -202,8 +202,8 @@ private:
         return jcp.is_reduced_rtus && (!get_extra_m_kernel_req(jcp));
     }
 
-    brgemm_containers::brgemm_kernel_container_t brg_kernels_ {32};
-    brgemm_containers::brgemm_palette_container_t brgemm_palettes_ {32};
+    brgemm_containers::brgemm_kernel_container_t brg_kernels_ {64};
+    brgemm_containers::brgemm_palette_container_t brgemm_palettes_ {64};
 
     std::unique_ptr<jit_avx512_core_brgemm_conv_trans_kernel::
                     jit_avx512_core_brgemm_conv_rtus_kernel_t>


### PR DESCRIPTION
# Description
the idx range of idx is double of fork onednn3.6 in openvino, fixed by xuchen
https://github.com/azhai219/oneDNN/blob/2577b22964d336bc10c52f5190493f1d097a1509/src/cpu/x64/jit_brgemm_1x1_conv.hpp#L176-L184
master: 
https://github.com/openvinotoolkit/oneDNN/blob/2b484815778e793afcd37289aef6aae17b7964b8/src/cpu/x64/jit_brgemm_1x1_conv.hpp#L164-L170


