### PR TITLE
[FORK][FIX] fix webassembly compilation

### DIFF
--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -376,7 +376,12 @@ namespace {
 inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
     using namespace Xbyak::util;
 
-    unsigned cpu_isa_mask = x64::get_max_cpu_isa_mask(soft);
+#if DNNL_X64
+    const unsigned cpu_isa_mask = x64::get_max_cpu_isa_mask(soft);
+#else
+    // only used for webassembly compilation
+    const unsigned cpu_isa_mask = isa_undef;
+#endif
     unsigned cpu_isa_no_hints = cpu_isa & ~cpu_isa_hints_utils::hints_mask;
 
     if ((cpu_isa_mask & cpu_isa_no_hints) != cpu_isa_no_hints) return false;


### PR DESCRIPTION
# Description
in webassembly compilation, dnnl didn't compile the code under src/cpu/x64, but openvino use header file in src/cpu/x64/cpu_isa_traits.hpp directly, which case can't find some symbol undefined symbol: dnnl::impl::cpu::x64::get_max_cpu_isa_mask(bool) issue, this fix is a workround


